### PR TITLE
Load modules from GitHub API

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,9 @@
     <!-- Chat for homepage -->
     <script src="/scripts/chat.js"></script>
 
+    <!-- Populate modules form GitHub -->
+    <script src="/scripts/modules.js"></script>
+
     <!-- Google Analytics -->
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -33,31 +33,21 @@ layout: default
       <p>
         Connector modules transfer messages between opsdroid and a particular chat service.
       </p>
-      <p>
-        <a href="https://github.com/opsdroid/connector-slack">Slack</a>
-        <a href="https://github.com/opsdroid/connector-shell">Shell</a>
-      </p>
+      <p id="connectors"></p>
     </div>
     <div class="col-md-4 modules">
       <h2>Databases</h2>
       <p>
         Database modules allow opsdroid to persist information in a database of your choice.
       </p>
-      <p>
-        <a href="https://github.com/opsdroid/database-mongo">MongoDB</a>
-      </p>
+      <p id="databases"></p>
    </div>
     <div class="col-md-4 modules">
       <h2>Skills</h2>
       <p>
         Skills are what makes opsdroid tick. They define how opsdroid should respond and what actions to take.
       </p>
-      <p>
-        <a href="https://github.com/opsdroid/skill-hello">Hello World</a>
-        <a href="https://github.com/opsdroid/skill-seen">Last Seen</a>
-        <a href="https://github.com/opsdroid/skill-dance">Dance</a>
-        <a href="https://github.com/opsdroid/skill-loudnoises">Loud Noises</a>
-      </p>
+      <p id="skills"></p>
     </div>
   </div>
 </div>

--- a/scripts/modules.js
+++ b/scripts/modules.js
@@ -1,0 +1,55 @@
+(function(){ //begin script
+
+  var append_modules = function(list, target){
+    $.each(list, function( _, repo ) {
+      $( "<a/>", {
+        "href": repo.html_url,
+        "title": repo.description,
+        html: repo.real_name
+      }).appendTo( target );
+    });
+  }
+
+  var sortByKey = function(array, key) {
+    return array.sort(function(a, b) {
+        var x = a[key]; var y = b[key];
+        return ((x < y) ? -1 : ((x > y) ? 1 : 0));
+    });
+  }
+
+  $(document).ready(function() {
+    if ( $(".modules").length ) {
+
+      // Load repos from GitHub Api
+      $.getJSON( "https://api.github.com/orgs/opsdroid/repos", function( data ) {
+        var connectors = [];
+        var databases = [];
+        var skills = [];
+        $.each( data, function( _, repo ) {
+          if (repo.name.search("skill-") == 0) {
+            repo.real_name = repo.name.substring(6)
+            skills.push(repo)
+          }
+          if (repo.name.search("database-") == 0) {
+            repo.real_name = repo.name.substring(9)
+            databases.push(repo)
+          }
+          if (repo.name.search("connector-") == 0) {
+            repo.real_name = repo.name.substring(10)
+            connectors.push(repo)
+          }
+          console.log(repo)
+        });
+
+        // Update page
+        append_modules(sortByKey(connectors, "stargazers_count"), "#connectors")
+        append_modules(sortByKey(databases, "stargazers_count"), "#databases")
+        append_modules(sortByKey(skills, "stargazers_count"), "#skills")
+
+
+      });
+
+    }
+  });
+
+})(); // end script


### PR DESCRIPTION
Instead of updating the website when a new module is pushed it now accesses the list of repos directly via the API and uses that to populate the three module sections.