### PR TITLE
Added margin to code box

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -123,7 +123,7 @@ body {
     @media (max-width: $on-laptop) {
       display: block;
       font-size: 1em;
-      margin: 3em 2em 0 2em;
+      margin: 3em 2em;
     }
   }
 


### PR DESCRIPTION
Here is an example with some additional margin on the code box as suggested in #17.
![after](https://user-images.githubusercontent.com/14238362/31692999-91df489e-b39c-11e7-82a7-a9c1c5fb77ee.png)
