### PR TITLE
404 Error image not loding for long URLs.

### DIFF
--- a/404.html
+++ b/404.html
@@ -23,6 +23,6 @@ layout: default
 </style>
 
 <div class="container">
-  <img  class="image" src="../../../../../../../../../images/404.svg">
+  <img  class="image" src="https://opsdroid.github.io/images/404.svg">
   <h1>Oops... Opsdroid couldn't find that page...</h1>
 </div>

--- a/404.html
+++ b/404.html
@@ -23,6 +23,6 @@ layout: default
 </style>
 
 <div class="container">
-  <img  class="image" src="https://opsdroid.github.io/images/404.svg">
+  <img  class="image" src="../images/404.svg">
   <h1>Oops... Opsdroid couldn't find that page...</h1>
 </div>

--- a/404.html
+++ b/404.html
@@ -23,6 +23,6 @@ layout: default
 </style>
 
 <div class="container">
-  <img  class="image" src="../images/404.svg">
+  <img  class="image" src="../../../../../../../../../images/404.svg">
   <h1>Oops... Opsdroid couldn't find that page...</h1>
 </div>

--- a/404.html
+++ b/404.html
@@ -23,6 +23,6 @@ layout: default
 </style>
 
 <div class="container">
-  <img  class="image" src="../images/404.svg">
+  <img  class="image" src="/images/404.svg">
   <h1>Oops... Opsdroid couldn't find that page...</h1>
 </div>


### PR DESCRIPTION
The **relative file path is updated** so that it can **load 404 error** image even if the wrong URL extends **more than two** sub-directories.