### PR TITLE
Add pull request template to get more context when PR's are open

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,19 +6,3 @@ Fixes #<issue>
 
 ## Status
 **READY** | **UNDER DEVELOPMENT** | **ON HOLD**
-
-## Type of change
-
-_Please delete options that are not relevant._
-
-- Bug fix (non-breaking change which fixes an issue)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- This change requires a documentation update
-- Documentation (fix or adds documentation)
-
-
-# Checklist:
-
-- [ ] I have performed a self-review of my own code
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+# Description
+
+_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context._
+
+Fixes #<issue>
+
+## Status
+**READY** | **UNDER DEVELOPMENT** | **ON HOLD**
+
+## Type of change
+
+_Please delete options that are not relevant._
+
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
+- Documentation (fix or adds documentation)
+
+
+# Checklist:
+
+- [ ] I have performed a self-review of my own code
+


### PR DESCRIPTION
I've copied the template that we are using on the main opsdroid repo and decided to use it on the site as well since we had a PR that got merged but didn't close the issue since it didn't have the text closes/fixes <issue number>

Hopefully this template will motivate contributors to explain why they decided that a change should be made when opening a PR.