### PR TITLE
#37 Fix documentation links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,8 +33,8 @@
   </div>
   <div class="bottom-footer">
     <div class="navigation-footer align-left">
-      <a href="http://opsdroid.readthedocs.io/en/latest/?badge=latest">Getting Started</a>
-      <a href="http://opsdroid.readthedocs.io/en/stable/">Documentation</a>
+      <a href="http://docs.opsdroid.dev/en/latest/?badge=latest">Getting Started</a>
+      <a href="http://docs.opsdroid.dev/en/stable/">Documentation</a>
       <a href="https://medium.com/opsdroid">Blog</a>
       <a href="https://github.com/opsdroid/opsdroid-desktop">Desktop</a>
       <a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org">Community</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,8 +10,8 @@
     <span class="icon-bar"></span>
   </button>
   <ul class="navigation">
-    <li><a href="http://opsdroid.readthedocs.io/en/latest/?badge=latest">Getting Started</a></li>
-    <li><a href="http://opsdroid.readthedocs.io/en/stable/">Documentation</a></li>
+    <li><a href="http://docs.opsdroid.dev/en/latest/?badge=latest">Getting Started</a></li>
+    <li><a href="http://docs.opsdroid.dev/en/stable/">Documentation</a></li>
     <li><a href="https://medium.com/opsdroid">Blog</a></li>
     <li><a href="https://github.com/opsdroid/opsdroid-desktop">Desktop</a></li>
     <li><a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org">Community</a></li>

--- a/index.html
+++ b/index.html
@@ -42,10 +42,10 @@ layout: default
       <p>
         Connector modules transfer messages between opsdroid and a particular chat service.
       </p>
-    
+
       <p id="connectors"></p>
     </div>
-  
+
     <div class="modules databases">
       <h2>Databases</h2>
       <p>
@@ -53,22 +53,22 @@ layout: default
       </p>
       <p id="databases"></p>
    </div>
-  
+
    <div class="modules parsers">
     <h2>Parsers</h2>
     <p>
       Parsers/Matchers modules gather meaning of what was said and match a skill.
     </p>
     <p id="parsers">
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/regex/" title="Matcher Regex">Regex</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/rasanlu/" title="Matcher Rasa">Rasa</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/dialogflow/" title="Matcher Dialogflow">Dialogflow</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/luis.ai/" title="Matcher LuisAI">Luis.AI</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/wit.ai/" title="Matcher WitAI">Wit.ai</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/crontab/" title="Matcher Crontab">Crontab</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/webhook/" title="Matcher Webhook">Webhook</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/always/" title="Matcher Always">Always</a>
-      <a href="https://opsdroid.readthedocs.io/en/latest/matchers/recast.ai/" title="Matcher RecastAI">Recast.AI</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/regex/" title="Matcher Regex">Regex</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/rasanlu/" title="Matcher Rasa">Rasa</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/dialogflow/" title="Matcher Dialogflow">Dialogflow</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/luis.ai/" title="Matcher LuisAI">Luis.AI</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/wit.ai/" title="Matcher WitAI">Wit.ai</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/crontab/" title="Matcher Crontab">Crontab</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/webhook/" title="Matcher Webhook">Webhook</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/always/" title="Matcher Always">Always</a>
+      <a href="https://docs.opsdroid.dev/en/latest/matchers/recast.ai/" title="Matcher RecastAI">Recast.AI</a>
 
     </p>
     </div>


### PR DESCRIPTION
Changed links from _opsdroid.readthedocs.io_ to _docs.opsdroid.dev_ in files:

index.html
_includes/footer.html
_includes/header.html