### PR TITLE
Switch links pointing to riot.im/app to app.element.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Now you can just head over to `http://localhost:4000` and see your live version 
 
 Contributing to the opsdroid ecosystem is strongly encouraged and every little bit counts! We even send [sticker packs](https://medium.com/opsdroid/contributor-sticker-packs-738058ceda59) to our contributors to say thank you! 
 
-Do you need help? Do you want to chat? [Join our Matrix channel](https://riot.im/app/#/room/#opsdroid-general:matrix.org)
+Do you need help? Do you want to chat? [Join our Matrix channel](https://app.element.io/#/room/#opsdroid-general:matrix.org)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
         <a href="https://github.com/{{ site.github_username }}" class="social-icon" title="Opsdroid Github Repo">
           {% include_relative /images/icons/github-brands.svg %}
         </a>
-        <a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org" class="social-icon" title="Opsdroid Matrix Channel">
+        <a href="https://app.element.io/#/room/#opsdroid-general:matrix.org" class="social-icon" title="Opsdroid Matrix Channel">
           {% include_relative /images/icons/comment-alt-solid.svg %}
         </a>
         <a href="https://twitter.com/{{ site.twitter_username }}" class="social-icon" title="Opsdroid Twitter Account">
@@ -34,7 +34,7 @@
       <a href="https://docs.opsdroid.dev/en/stable/">Documentation</a>
       <a href="https://medium.com/opsdroid">Blog</a>
       <a href="https://github.com/opsdroid/opsdroid-desktop">Desktop</a>
-      <a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org">Community</a>
+      <a href="https://app.element.io/#/room/#opsdroid-general:matrix.org">Community</a>
     </div>
     <div class="license">
       <p class="align-left">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
     <li><a href="https://docs.opsdroid.dev/en/stable/">Documentation</a></li>
     <li><a href="https://medium.com/opsdroid">Blog</a></li>
     <li><a href="https://github.com/opsdroid/opsdroid-desktop">Desktop</a></li>
-    <li><a href="https://riot.im/app/#/room/#opsdroid-general:matrix.org">Community</a></li>
+    <li><a href="https://app.element.io/#/room/#opsdroid-general:matrix.org">Community</a></li>
     <li class="visible-xs"><a href="https://github.com/{{site.github_username}}">Fork me on GitHub!</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
# Description

Riot has rebranded to [Element](https://element.io). One day links to riot.im will probably stop working. This PR updates them to their equivalent on element.io.

## Status
**READY**