### PR TITLE
fix: font-family now resembles with the page

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -438,8 +438,8 @@ nav {
 
   .modules-intro {
     text-align: center;
-    font-family: "Montserrat";
-    font-size: 1.3rem;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 1.4rem;
     position: sticky;
     z-index: 2;
 


### PR DESCRIPTION
# Description
* font-family: 'Montserrat', sans-serif; added to heading - "All your needs in one single framework."
* Size of the same is also changed from 1.3rem to 1.4rem.
Fixes #69 

## Status
**READY** 

## Previous View
![Screenshot (34)](https://user-images.githubusercontent.com/51539117/189030140-62f8843c-05e0-4798-8496-d7723267096c.png)

## Current View
![Screenshot (36)](https://user-images.githubusercontent.com/51539117/189030332-1e15a9e5-8738-48b4-93b3-e9dec0e0d122.png)
